### PR TITLE
add strictObject

### DIFF
--- a/test/validators/object-test.ts
+++ b/test/validators/object-test.ts
@@ -117,21 +117,21 @@ QUnit.test(`simple ${validators.strictObject.name}`, async assert => {
 
   assert.equal(
     format(validates(geo)),
-    `(pipe (is-object) (all (all-fields-present lat=(is-number) long=(is-number)) (no-fields-extra lat=(is-number) long=(is-number))) (fields lat=(is-number) long=(is-number)))`
+    `(pipe (is-object) (keys "lat" "long") (fields lat=(is-number) long=(is-number)))`
   );
 
   assert.deepEqual(await run(geo, { lat: 0, long: 0 }), success());
 
   assert.deepEqual(await run(geo, { lat: 0 }), [
-    failure("long", "present", null)
+    failure("long", "type", "present")
   ]);
 
   assert.deepEqual(await run(geo, { lat: 0, long: 0, extraData: 1 }), [
-    failure("extraData", "absent", null)
+    failure("extraData", "type", "absent")
   ]);
 
   assert.deepEqual(await run(geo, { lat: 0, extraData: 1 }), [
-    failure("long", "present", null),
-    failure("extraData", "absent", null)
+    failure("long", "type", "present"),
+    failure("extraData", "type", "absent")
   ]);
 });

--- a/test/validators/object-test.ts
+++ b/test/validators/object-test.ts
@@ -108,3 +108,30 @@ type ObjectBuilder = (
     ]);
   });
 });
+
+QUnit.test(`simple ${validators.strictObject.name}`, async assert => {
+  const geo = validators.strictObject({
+    lat: validators.isNumber(),
+    long: validators.isNumber()
+  });
+
+  assert.equal(
+    format(validates(geo)),
+    `(pipe (is-object) (all (all-fields-present lat=(is-number) long=(is-number)) (no-fields-extra lat=(is-number) long=(is-number))) (fields lat=(is-number) long=(is-number)))`
+  );
+
+  assert.deepEqual(await run(geo, { lat: 0, long: 0 }), success());
+
+  assert.deepEqual(await run(geo, { lat: 0 }), [
+    failure("long", "present", null)
+  ]);
+
+  assert.deepEqual(await run(geo, { lat: 0, long: 0, extraData: 1 }), [
+    failure("extraData", "absent", null)
+  ]);
+
+  assert.deepEqual(await run(geo, { lat: 0, extraData: 1 }), [
+    failure("long", "present", null),
+    failure("extraData", "absent", null)
+  ]);
+});


### PR DESCRIPTION
This new strictObject validator makes sure that all fields are present in the value under validation. It also makes sure that the value does not contain any extra fields that are not specified in the validator declaration. The normal object validator simply ignores extra fields and also does not care if some specified fields are missing as long as the missing value (`undefined`) passes the validation for said field.